### PR TITLE
Update 2026.3 event details

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,11 @@ while(x=eval(x));
 
         <a href="https://www.meetup.com/nslondon/events/314881943/"><h1 id="2026-3">2026.3 at Flo</h1></a>
 
-        <h2>Event details coming soon!</h2>
+        <h2>Harry Davies — The Living Spec: Rethinking How We Direct Agents</h2>
+
+        <h2>Anastasia Petrova — Crossing the Boundary: From Feature Team to Platform Team</h2>
+
+        <h2>James Coleman — Using ARKit for Facial Rehab</h2>
           <br>
 
         <a href="https://www.meetup.com/nslondon/events/314110467/"></a><h1 id="wwdc26">WWDC26 at NewDay</h1>


### PR DESCRIPTION
## Summary

- replace the placeholder for NSLondon 2026.3 at Flo with the confirmed agenda
- add the three speaker and talk titles from the Meetup listing

## Why

The event entry was created before the full agenda was available. Updating it gives visitors the current speaker lineup.

## Impact

The NSLondon website will show the confirmed talks for the July 2026 event instead of “Event details coming soon!”.

## Validation

- `git diff --check HEAD^ HEAD`
